### PR TITLE
fix: follow a user

### DIFF
--- a/app/Actions/User/FollowUserAction.php
+++ b/app/Actions/User/FollowUserAction.php
@@ -11,7 +11,7 @@ class FollowUserAction
     {
         $userIsFollowed = $follower
             ->following()
-            ->where('followed_id', $following->id)
+            ->where('following_id', $following->id)
             ->exists();
 
         if (! $userIsFollowed) {


### PR DESCRIPTION
change `->where('followed_id', $following->id)` to `->where('following_id', $following->id)` because followed_id did't exist in followers table